### PR TITLE
EXT4 CI changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ tags/
 .vscode/
 Build/
 Conf/
+node_modules/
+package.json
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,3 @@ tags/
 .vscode/
 Build/
 Conf/
-node_modules/
-package.json
-package-lock.json

--- a/Features/Ext4Pkg/Ext4Pkg.ci.yaml
+++ b/Features/Ext4Pkg/Ext4Pkg.ci.yaml
@@ -73,6 +73,22 @@
         "IgnoreFiles": [             # use gitignore syntax to ignore errors in matching files
         ],
         "ExtendWords": [           # words to extend to the dictionary for this package
+            "compr",
+            "comprblk",
+            "dblocks",
+            "falcato",
+            "igeneration",
+            "incompat",
+            "isize",
+            "itable",
+            "kbytes",
+            "masix",
+            "mitrofanov",
+            "nocompr",
+            "projid",
+            "savva",
+            "secrm",
+            "wtime"
         ],
         "AdditionalIncludePaths": [] # Additional paths to spell check relative to package root (wildcards supported)
     }


### PR DESCRIPTION
I expanded the SpellCheck dictionary for Ext4Pkg. There will be a separate patch to the upstream with the actual typo fixes, so this does not work as-is. I also added some things to .gitignore, which the CI build process dumped into my repository root.